### PR TITLE
setup.py: add install dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,4 +15,5 @@ setuptools.setup(
     url="https://github.com/rajlaud/pysqueezebox",
     packages=setuptools.find_packages(),
     python_requires=">=3.6",
+    install_requires=["aiohttp"],
 )


### PR DESCRIPTION
Hello,

I am packaging this library for NixOS https://github.com/NixOS/nixpkgs/pull/96689 and I noticed that the aiohttp dependency is not checked by the setup.py
This patch is not mandatory for the packaging but I thought it's nice to have this.

Also the tests are missing in the sdist package from pypi, is this intentional ?