### PR TITLE
Update setup.py, exclude 'tests'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/rajlaud/pysqueezebox",
-    packages=setuptools.find_packages(),
+    packages=setuptools.find_packages(exclude=['tests','tests.*']),
     python_requires=">=3.6",
     install_requires=["aiohttp", "async-timeout"],
 )


### PR DESCRIPTION
Otherwise:

```
* python3_11: running distutils-r1_run_phase distutils-r1_python_install
 * The following unexpected files/directories were found top-level
 * in the site-packages directory:
 *
 *   /usr/lib/python3.11/site-packages/tests
 *
 * This is most likely a bug in the build system.  More information
 * can be found in the Python Guide:
 * https://projects.gentoo.org/python/guide/qawarn.html#stray-top-level-files-in-site-packages
 * ERROR: dev-python/pysqueezebox-0.7.1::HomeAssistantRepository failed (install phase):
 *   Failing install because of stray top-level files in site-packages
```

I hope you don't mind I included your component for [Home Assistant Gentoo Overlay](https://github.com/onkelbeh/HomeAssistantRepository). I do not use this component myself. But, during compilation test, the installation test script threw an error, because `setup.py` tries to install a package called `tests` at top level.
My change only adds a generic exclusion to find_packages().