### PR TITLE
Add modelname to Player class

### DIFF
--- a/pysqueezebox/player.py
+++ b/pysqueezebox/player.py
@@ -58,7 +58,7 @@ class Player:
 
     @property
     def model(self):
-        """Return the player models name, e.g. Squeezebox Boom"""
+        """Return the players model name, e.g. Squeezebox Boom"""
         return self._model
 
     @property

--- a/pysqueezebox/player.py
+++ b/pysqueezebox/player.py
@@ -1,4 +1,5 @@
 """The pysqueezebox.Player() class."""
+
 import asyncio
 import logging
 import async_timeout
@@ -18,7 +19,7 @@ POLL_INTERVAL = 0.75
 class Player:
     """Representation of a SqueezeBox device."""
 
-    def __init__(self, lms, player_id, name, status=None):
+    def __init__(self, lms, player_id, name, status=None, model=None):
         """
         Initialize the SqueezeBox device.
 
@@ -34,6 +35,7 @@ class Player:
         self._playlist_timestamp = 0
         self._playlist_tags = None
         self._name = name
+        self._model = model
 
         self._property_futures = []
         self._poll = None
@@ -53,6 +55,11 @@ class Player:
     def player_id(self):
         """Return the player ID, which is its MAC address."""
         return self._id
+
+    @property
+    def model(self):
+        """Return the player models name, e.g. Squeezebox Boom"""
+        return self._model
 
     @property
     def connected(self):

--- a/pysqueezebox/server.py
+++ b/pysqueezebox/server.py
@@ -88,9 +88,23 @@ class Server:
         for player in data.get("players_loop", []):
             if search:
                 if search.lower() in player["name"].lower():
-                    players.append(Player(self, player["playerid"], player["name"]))
+                    players.append(
+                        Player(
+                            self,
+                            player["playerid"],
+                            player["name"],
+                            model=player.get("modelname", None),
+                        )
+                    )
             else:
-                players.append(Player(self, player["playerid"], player["name"]))
+                players.append(
+                    Player(
+                        self,
+                        player["playerid"],
+                        player["name"],
+                        model=player.get("modelname", None),
+                    )
+                )
         _LOGGER.debug("get_players(%s) returning players: %s", search, players)
         return players
 


### PR DESCRIPTION
Small PR to add modelname to the Player class.  The players status query returns the modelname, so I thought we might as well expose this in the Player class so that we can include it in the media_player device.