### PR TITLE
get alarm data during status request to fetch information on next alarm

### DIFF
--- a/pysqueezebox/player.py
+++ b/pysqueezebox/player.py
@@ -62,6 +62,8 @@ AlarmJSON = TypedDict(
 PlayerStatus = TypedDict(
     "PlayerStatus",
     {
+        "alarm_next": int,
+        "alarm_state": str,
         "player_connected": int,
         "power": int,
         "mode": str,
@@ -420,6 +422,16 @@ class Player:
         return None
 
     @property
+    def alarm_state(self) -> str | None:
+        """Return the current alarm state"""
+        return self._status.get("alarm_state")
+
+    @property
+    def alarm_next(self) -> int | None:
+        """Return the time stamp of the next alarm (seconds since the epoch)"""
+        return self._status.get("alarm_next")
+
+    @property
     def playlist_urls(self) -> list[PlaylistEntry] | None:
         """Return only the urls of the current playlist. Useful for comparing playlists."""
         if not self.playlist:
@@ -519,7 +531,7 @@ class Player:
         tags = "acdIKlNorTuxQ"
         if add_tags:
             tags = "".join(set(tags + add_tags))
-        response = await self.async_query("status", "-", "1", f"tags:{tags}")
+        response = await self.async_query("status", "-", "1", f"tags:{tags}", "alarmData:1")
 
         if response is None:
             return False

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -658,12 +658,16 @@ async def test_alarms(player: Player) -> None:
     await player.async_update()
     assert player.alarms is not None
     assert len(player.alarms) == 1
+    assert player.alarm_next == 0
+    assert player.alarm_state == "none"
     assert player.alarms[0]["time"] == time
     assert player.alarms[0]["enabled"] is False
     assert player.alarms[0]["id"] == alarm_id
 
     await player.async_update_alarm(alarm_id, enabled=True)
     await player.async_update()
+    assert player.alarm_next != 0
+    assert player.alarm_state == "set"
     assert player.alarms is not None
     assert len(player.alarms) == 1
     assert player.alarms[0]["enabled"] is True


### PR DESCRIPTION
Adds information if and when an alarm is scheduled within the next 24 hours. Can be used to have a HA sensor showing this information. 