### PR TITLE
Add support for media_player.search_media action

### DIFF
--- a/pysqueezebox/player.py
+++ b/pysqueezebox/player.py
@@ -125,7 +125,7 @@ def _parse_alarm_params(params: Alarm) -> list[str]:
     for key, value in params.items():
         if key == "time" and params["time"] is not None:
             time = params["time"]
-            parlist.append(f"{key}:{time.hour*3600 + time.minute*60 + time.second}")
+            parlist.append(f"{key}:{time.hour * 3600 + time.minute * 60 + time.second}")
         if key == "dow" and params["dow"] is not None:
             dow = params["dow"]
             parlist.append(f"{key}:{','.join(map(str, dow))}")
@@ -1152,6 +1152,7 @@ class Player:
         category: str,
         limit: int | None = None,
         browse_id: tuple[str, str] | None = None,
+        search_query: str | None = None,
     ) -> QueryResult | None:
         """
         Browse the music library.
@@ -1159,7 +1160,11 @@ class Player:
         See Server.async_browse for parameters.
         """
         return await self._lms.async_browse(
-            category, limit=limit, browse_id=browse_id, player_id=self._id
+            category,
+            limit=limit,
+            browse_id=browse_id,
+            player_id=self._id,
+            search_query=search_query,
         )
 
     def generate_image_url_from_track_id(self, track_id: int) -> str:


### PR DESCRIPTION
The new search media action allows searching the media library.  Currently it's just an action but is intended to add search capability to the media browser.

I've added support for this in media_player and browse_media by re-using and extending build_item_response to take an optional search string parameter in addition to the media_content_id.  This means all of the work already done around building the response correctly for the media browser when browsing is reused for the search.  Basically, this PR just passes the search string through player async_browse to server async_browse.