### PR TITLE
Fix alarm handling when day of week is None

### DIFF
--- a/pysqueezebox/player.py
+++ b/pysqueezebox/player.py
@@ -489,10 +489,12 @@ class Player:
                 seconds = int(alarm["time"])
                 minutes, seconds = divmod(seconds, 60)
                 hours, minutes = divmod(minutes, 60)
+                dow = list(map(int, alarm["dow"].split(","))) if alarm["dow"] else []
+
                 result.append(
                     {
                         "time": dt_time(second=seconds, minute=minutes, hour=hours),
-                        "dow": list(map(int, alarm["dow"].split(","))),
+                        "dow": dow,
                         "enabled": alarm["enabled"] == "1",
                         "repeat": alarm["repeat"] == "1",
                         "volume": int(alarm["volume"]),


### PR DESCRIPTION
If you have an alarm which has no days selected (i.e. to stop it from running), splitting the dow value causes the integration to error, marking that player unavailable.  This PR just creates an empty list if dow is none.