### PR TITLE
Fix for next and previous tracks

### DIFF
--- a/pysqueezebox/player.py
+++ b/pysqueezebox/player.py
@@ -833,12 +833,6 @@ class Player:
                 return False
             target_index = self.current_index + int(index)
 
-            _LOGGER.critical(
-                "Target index %s, Playlist_tracks %s",
-                target_index,
-                self.playlist_tracks,
-            )
-
             # index is zero based, playlist_tracks is the number of tracks
             if self.playlist_tracks and target_index >= self.playlist_tracks:
                 target_index = 0

--- a/pysqueezebox/player.py
+++ b/pysqueezebox/player.py
@@ -832,6 +832,19 @@ class Player:
                 )
                 return False
             target_index = self.current_index + int(index)
+
+            _LOGGER.critical(
+                "Target index %s, Playlist_tracks %s",
+                target_index,
+                self.playlist_tracks,
+            )
+
+            # index is zero based, playlist_tracks is the number of tracks
+            if self.playlist_tracks and target_index >= self.playlist_tracks:
+                target_index = 0
+
+            if self.playlist_tracks and target_index < 0:
+                target_index = self.playlist_tracks - 1
         else:
             target_index = int(index)
 


### PR DESCRIPTION
In player, when you do next on the last track in the playlist, or previous in the first track, LMS switches to the first or last track respectively - i.e. it rolls around the end.  However, we don't currently handle that when checking for the new track number.  This fix just handles that condition.